### PR TITLE
Syn bio

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/attributions.html
+++ b/attributions.html
@@ -71,12 +71,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/background.html
+++ b/background.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/blog.html
+++ b/blog.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/collaborations.html
+++ b/collaborations.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/contact.html
+++ b/contact.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/domains.html
+++ b/domains.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/gallery.html
+++ b/gallery.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/indc.html
+++ b/indc.html
@@ -71,12 +71,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/index.html
+++ b/index.html
@@ -74,12 +74,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/join.html
+++ b/join.html
@@ -71,12 +71,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/projectarchive.html
+++ b/projectarchive.html
@@ -69,12 +69,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/resource.html
+++ b/resource.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/sponsors.html
+++ b/sponsors.html
@@ -71,12 +71,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/substrate.html
+++ b/substrate.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/synbio.html
+++ b/synbio.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>

--- a/team.html
+++ b/team.html
@@ -70,12 +70,11 @@
                         </li>-->
                         <li class="text-center"><a href="projectarchive.html">Projects</a></li>
                         <li class="text-center"><a href="gallery.html">Photo Gallery</a></li>
+                        <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                         <li class="dropdown text-center">
                           <button id=dLabel href="#" class="dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false">Get Involved <span class="caret"></span></button>
                           <ul class="dropdown-menu" aria-labelledby="dLabel">
                             <li class="text-center"><a href="join.html">Join the Team</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li class="text-center"><a href="resource.html">SynBio Resources</a></li>
                             <li role="separator" class="divider"></li>
                             <li class="text-center"><a href="sponsors.html">Sponsors</a></li>
                           </ul>


### PR DESCRIPTION
Janis requested that instead of having the synbio resources link be a part of the dropdown menu in get involved tab, it should have its own section in the navbar. I removed the synbio link from the dropdown menu and added it to the navbar for all the html pages. the first commit was for updating the active pages while the second commit was for updating the currently unused pages (ex. attributions, blog, etc) in case they are used in the future. I also tested the changes in chrome to verify that the new synbio resources link showed up and worked.